### PR TITLE
Implementing Multi-Stage Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
-FROM openjdk:8
+# Stage 1: Build the application
+FROM maven:3.8.4 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn package -DskipTests
+
+# Stage 2: Package the application into a smaller image
+FROM openjdk:8-jre-slim
+WORKDIR /app
+COPY --from=build /app/target/springboot-images-new.jar .
 EXPOSE 8080
-ADD target/springboot-images-new.jar springboot-images-new.jar
-ENTRYPOINT ["java","-jar","/springboot-images-new.jar"]
+ENTRYPOINT ["java", "-jar", "springboot-images-new.jar"]


### PR DESCRIPTION
By separating build and runtime environments, it significantly reduces the final image size, leading to faster deployments and resource efficiency.

![image](https://github.com/Java-Techie-jt/github-actions-example/assets/81347482/ba486411-d5ff-4440-bfc7-0378fcd452cd)

Initial image size was reduced from 544 MB to 212 MB, a 61% decrease, showcasing the effectiveness of the approach. for these Dockerfile